### PR TITLE
Adjust sidebar level

### DIFF
--- a/src/styles/guide/_sidebar.scss
+++ b/src/styles/guide/_sidebar.scss
@@ -1,6 +1,7 @@
 .sidebar {
   position: fixed;
   top: 0;
+  z-index: 1;
   width: 12em;
   padding: 1em;
 


### PR DESCRIPTION
On a narrow screen sizes parts of sidebar links are non-clickable:
<video src="https://user-images.githubusercontent.com/65758149/122231969-8e85a580-cec3-11eb-89c8-a2caa8086f1e.mp4" controls />

That's because of main column overlapping the sidebar:
<img width="339" alt="Screenshot 2021-06-16 at 16 58 56" src="https://user-images.githubusercontent.com/65758149/122232789-2b484300-cec4-11eb-9ffe-00caf4a4e2ed.png" />

This PR fixes this by adjusting rendering level of sidebar.


